### PR TITLE
Add slightly more elaborate express sample

### DIFF
--- a/glues/Express/README.md
+++ b/glues/Express/README.md
@@ -5,7 +5,22 @@ Binding for [Express](https://github.com/expressjs/express)
 # Usage
 
 ```fs
+open Fable.Core
 open Glutinum.Express
 
+let port = 2700
 let app = express.express ()
+
+app.get (
+    "/",
+    fun (req: Glutinum.ExpressServeStaticCore.Request) (res: Glutinum.ExpressServeStaticCore.Response) ->
+        JS.console.log ($"New request, %s{req.hostname}")
+        res.send ("Hello world")
+)
+
+app.listen (
+    port,
+    fun () -> JS.console.log $"Started listening on http://127.0.0.1:%i{port}"
+)
+|> ignore
 ```


### PR DESCRIPTION
I tried to play with this, took me a while until I figured out that `Express.Request` doesn't work and needs to be `Glutinum.ExpressServeStaticCore.Request`.